### PR TITLE
[TRE-280] Add codeowners for tl-pax8

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Codeowners for tl-pax8
+*   @treeline-inc/codeowners


### PR DESCRIPTION
## Project Management

*Linear Ticket*: [TRE-280: Make tl-pax8 a public repo](https://linear.app/treeline/issue/TRE-280/make-tl-pax8-a-public-repo)

## Description
Sets up codeowners for the tl-pax8 repo. We will follow-up this PR by updating the branch protection rules to require a review from a codeowner.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/QBZ8OsuCuWrhmDXQMpLd/5e81a85a-1644-43cf-8bd7-555c65150ab8.png)

## Testing Plan
N/A
