### PR TITLE
[TRE-410] Fix commitment term parsing

### DIFF
--- a/src/tl_pax8/models/subscription.py
+++ b/src/tl_pax8/models/subscription.py
@@ -160,7 +160,9 @@ class Subscription(BaseModel):
             "partnerCost": obj.get("partnerCost"),
             "billingTerm": obj.get("billingTerm"),
             "provisioningDetails": [ProvisioningDetail.from_dict(_item) for _item in obj["provisioningDetails"]] if obj.get("provisioningDetails") is not None else None,
-            "commitmentTerm": SubscriptionCommitment.from_dict(obj["commitmentTerm"]) if obj.get("commitmentTerm") is not None else None
+            # TREELINE CHANGE
+            # OpenAPI spec has commitmentTerm, but the actual field is commitment
+            "commitmentTerm": SubscriptionCommitment.from_dict(obj["commitment"]) if obj.get("commitment") is not None else None
         })
         return _obj
 


### PR DESCRIPTION
## Project Management

*Linear Ticket*: [TRE-410: Fix commitment term parsing](https://linear.app/treeline/issue/TRE-410/fix-commitment-term-parsing)

## Description
Fixes the "commitment term" field in the `subscriptions` response from `commitment_term` to `commitment`.

## Testing Plan
- [x] Use updated tl_pax8 api client in `pax8` data sync and confirm that commitment term is properly parsed